### PR TITLE
Feat/profile page#23

### DIFF
--- a/front/src/app/(main)/profile/ProfileItem.tsx
+++ b/front/src/app/(main)/profile/ProfileItem.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+interface Props {
+  title: string;
+  content: string;
+}
+
+export default function ProfileItem({ title, content }: Props) {
+  return (
+    <Wrapper>
+      <div>{title}</div>
+      <div>{content}</div>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  div:first-child {
+    margin-bottom: 1rem;
+  }
+
+  div:last-child {
+    padding: 1.5rem 2rem;
+    border-radius: 0.8rem;
+    color: ${({ theme }) => theme.colors.black};
+    background: ${({ theme }) => theme.colors.white};
+  }
+`;

--- a/front/src/app/(main)/profile/page.tsx
+++ b/front/src/app/(main)/profile/page.tsx
@@ -1,3 +1,89 @@
+'use client';
+
+import Toggle from '@/component/Toggle';
+import Buttons from '@/component/Buttons';
+import ProfileImage from '@/component/ProfileImage';
+import ProfileItem from '@/app/(main)/profile/ProfileItem';
+import useToggle from '@/hooks/useToggle';
+import styled from 'styled-components';
+
 export default function Profile() {
-  return <div>my profile page</div>;
+  const [follw, onChangeFollow] = useToggle(false);
+  const [block, onChangeBlock] = useToggle(false);
+
+  return (
+    <Container>
+      <TopWrapper>
+        <Wrapper $width={3}>
+          <ProfileImage url='' size='300px' />
+          <TogglesWrapper>
+            <Toggle
+              text='follow'
+              color='green'
+              checked={follw}
+              onToggle={onChangeFollow}
+            />
+            <Toggle
+              text='block'
+              color='pink'
+              checked={block}
+              onToggle={onChangeBlock}
+            />
+          </TogglesWrapper>
+        </Wrapper>
+        <Wrapper $width={7}>
+          <ProfileItem title='NAME' content='jabae' />
+          <ProfileItem title='MAIL' content='jabae@42seoul.com' />
+          <ProfileItem title='Win/Lose' content='32/1' />
+          <HistoryButton>
+            <span>Game History</span>
+            <span>{'>'}</span>
+          </HistoryButton>
+        </Wrapper>
+      </TopWrapper>
+      <Buttons
+        button={{ width: '20rem' }}
+        leftButton={{ text: 'direct message', color: 'white' }}
+        rightButton={{ text: 'match game', color: 'green' }}
+      />
+    </Container>
+  );
 }
+
+const Container = styled.div`
+  ${({ theme }) => theme.flex.centerColumn};
+  margin: 10rem 20rem;
+`;
+
+const TopWrapper = styled.div`
+  ${({ theme }) => theme.flex.center};
+  width: 100%;
+  height: 28rem;
+  margin-bottom: 10rem;
+`;
+
+const Wrapper = styled.div<{ $width: number }>`
+  flex: ${({ $width }) => $width};
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 0 2rem;
+  height: 100%;
+`;
+
+const TogglesWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 2rem auto;
+  width: 13rem;
+  height: 100%;
+`;
+
+const HistoryButton = styled.button`
+  padding: 1.5rem 2rem;
+  border-radius: 0.8rem;
+  color: ${({ theme }) => theme.colors.black};
+  background: ${({ theme }) => theme.colors.grey};
+  ${({ theme }) => theme.flex.spaceBetween};
+`;

--- a/front/src/component/Buttons/Button.tsx
+++ b/front/src/component/Buttons/Button.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export interface Props {
+  text: string;
+  color: string;
+  width?: string;
+}
+
+export default function Button({ text, color, width }: Props) {
+  return (
+    <WrapperButton $color={color} $width={width}>
+      {text}
+    </WrapperButton>
+  );
+}
+
+const WrapperButton = styled.button<{ $color: string; $width?: string }>`
+  ${({ theme }) => theme.flex.center};
+  border-radius: 0.8rem;
+  margin: 0 2rem;
+  padding: 0 0.2rem;
+  height: 3.5rem;
+  width: ${({ $width }) => $width || '15rem'};
+  color: ${({ theme }) => theme.colors.black};
+  background: ${({ $color, theme }) => theme.colors[$color]};
+`;

--- a/front/src/component/Buttons/index.tsx
+++ b/front/src/component/Buttons/index.tsx
@@ -1,0 +1,25 @@
+import Button from '@/component/Buttons/Button';
+import { Props as ButtonProps } from '@/component/Buttons/Button';
+import styled from 'styled-components';
+
+interface Props {
+  button?: {
+    width: string;
+  };
+  leftButton: ButtonProps;
+  rightButton: ButtonProps;
+}
+
+export default function Buttons({ button: b, leftButton, rightButton }: Props) {
+  return (
+    <Wrapper>
+      <Button {...{ ...leftButton, width: b?.width }} />
+      <Button {...{ ...rightButton, width: b?.width }} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.spaceBetween};
+  width: 100%;
+`;

--- a/front/src/component/Buttons/index.tsx
+++ b/front/src/component/Buttons/index.tsx
@@ -13,8 +13,8 @@ interface Props {
 export default function Buttons({ button: b, leftButton, rightButton }: Props) {
   return (
     <Wrapper>
-      <Button {...{ ...leftButton, width: b?.width }} />
-      <Button {...{ ...rightButton, width: b?.width }} />
+      <Button {...leftButton} width={b?.width} />
+      <Button {...rightButton} width={b?.width} />
     </Wrapper>
   );
 }

--- a/front/src/component/Toggle/index.tsx
+++ b/front/src/component/Toggle/index.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+
+interface Props {
+  text: string;
+  color: string;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+export default function Toggle({ text, color, checked, onToggle }: Props) {
+  return (
+    <Wrapper>
+      <ToggleLabel $color={color} htmlFor={`${text}-toggle`}>
+        <input
+          type='checkbox'
+          id={`${text}-toggle`}
+          checked={checked}
+          onChange={onToggle}
+        />
+        <SwitchSpan />
+      </ToggleLabel>
+      {text}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.spaceBetween};
+  justify-content: flex-start;
+`;
+
+const SwitchSpan = styled.span`
+  position: relative;
+  width: 4rem;
+  height: 2rem;
+  border-radius: 2rem;
+  background: ${({ theme }) => theme.colors.grey};
+  padding: 0.3rem;
+
+  &::before {
+    position: absolute;
+    content: '';
+    top: 50%;
+    left: 0.3rem;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.colors.white};
+    transform: translate(0, -50%);
+    transition: 300ms all;
+  }
+`;
+
+const ToggleLabel = styled.label<{ $color: string }>`
+  display: flex;
+  align-items: center;
+  margin-right: 2rem;
+  cursor: pointer;
+
+  input:checked + ${SwitchSpan} {
+    background: ${({ $color, theme }) => theme.colors[$color]};
+    &:before {
+      transform: translate(32px, -50%);
+    }
+  }
+`;

--- a/front/src/hooks/useToggle.ts
+++ b/front/src/hooks/useToggle.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from 'react';
+
+const useToggle = (initialData: boolean): [boolean, () => void] => {
+  const [toggle, setToggle] = useState(initialData);
+  const handler = useCallback(() => {
+    setToggle((prev) => !prev);
+  }, []);
+  return [toggle, handler];
+};
+
+export default useToggle;


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->
<!-- 제목 가장 앞에 [Feat] 또는 [Docs] 를 넣어주세요! -->
<!-- labels 에 documentation, enhancement, front-end 또는 back-end 등의 라벨을 넣어주세요! -->

## Summary
- 프로필 페이지 뷰 구현했습니다.
- 데이터는 Figma 보고 임의로 넣어두었습니다.
## Describe your changes
- 프로필 페이지 구현했습니다.
- 반복되는 유저 정보 리스트는 `ProfileItem`으로 컴포넌트로 추출해 구현했습니다.
- `Toggle` 컴포넌트와 `useToggle` 훅으로 만들어서 추후 모달이나 다른 페이지에서 사용할 수 있도록 만들었습니다. 
- `Buttons`, `Button` 컴포넌트로 만들어서 추후 모달에 사용할 수 있도록 만들었습니다. 
  - `Buttons`는 2개의 쌍, `Button`은 하나의 버튼입니다.
  - 색상, 텍스트, 넓이는 `props`로 받아 구성합니다. (넓이를 내려주지 않을 경우, `15rem`으로 기본 구성됩니다.)
## Issue number and link
- #23 
