### PR TITLE
[Feat] getUsetProfileDetailDto 추가 #84

### DIFF
--- a/back/web-app/src/users/me/dto/get-user-profile-details-res.dto.ts
+++ b/back/web-app/src/users/me/dto/get-user-profile-details-res.dto.ts
@@ -1,0 +1,10 @@
+import { TwoFactorStatus } from '../../enums/twoFactor-status.enum';
+
+export class GetUserProfileDetailsResDto {
+  readonly id: number;
+  readonly nickname: string;
+  readonly avatar: string;
+  readonly mail: string;
+  readonly phone: string;
+  readonly twoFactor: TwoFactorStatus;
+}

--- a/back/web-app/src/users/me/me.controller.ts
+++ b/back/web-app/src/users/me/me.controller.ts
@@ -1,13 +1,10 @@
-import { Controller, Get, Param, Session } from '@nestjs/common';
+import { Controller, Get, Session } from '@nestjs/common';
 import { MemoryUserService } from '../memoryuser/memory-user.service';
 import { Builder } from 'builder-pattern';
 import { FindUserDto } from '../memoryuser/dto/find-user.dto';
 import { GetUserProfileResDto } from './dto/get-user-profile-res.dto';
 import { GameRecordDto } from './dto/game-record.dto';
 import { GetUserProfileDetailsResDto } from './dto/get-user-profile-details-res.dto';
-import { GetUserByNicknameReqDto } from './dto/get-user-by-nickname-req.dto';
-import { FindUserByNicknameDto } from '../memoryuser/dto/find-user-by-nickname.dto';
-import { GetUserByNicknameResDto } from './dto/get-user-by-nickname-res.dto';
 
 @Controller('me')
 export class MeController {
@@ -46,31 +43,6 @@ export class MeController {
       .mail(me.mail)
       .phone(me.phone)
       .twoFactor(me.twoFactor)
-      .build();
-  }
-
-  @Get('users/:nickname')
-  getUserByNickname(@Session() session, @Param() dto: GetUserByNicknameReqDto) {
-    const me = this.memoryUserService.findUser(
-      Builder(FindUserDto).userId(session.userId).build(),
-    );
-    const findUser = this.memoryUserService.findUserByNickname(
-      Builder(FindUserByNicknameDto).nickname(dto.nickname).build(),
-    );
-
-    const gameRecodeDto = Builder(GameRecordDto)
-      .win(10)
-      .loss(10)
-      .ladderLevel(10)
-      .achievement(['0123456789abcdef', '0123456789abcdef'])
-      .build();
-    return Builder(GetUserByNicknameResDto)
-      .id(findUser.id)
-      .nickname(findUser.nickname)
-      .avatar(findUser.avatar)
-      .gameRecord(gameRecodeDto)
-      .isFriend(me.friends.has(findUser.id))
-      .isisBlock(me.blocks.has(findUser.id))
       .build();
   }
 }

--- a/back/web-app/src/users/me/me.controller.ts
+++ b/back/web-app/src/users/me/me.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Get, Put, Session } from '@nestjs/common';
+import { Controller, Get, Param, Session } from '@nestjs/common';
 import { MemoryUserService } from '../memoryuser/memory-user.service';
 import { Builder } from 'builder-pattern';
 import { FindUserDto } from '../memoryuser/dto/find-user.dto';
 import { GetUserProfileResDto } from './dto/get-user-profile-res.dto';
 import { GameRecordDto } from './dto/game-record.dto';
 import { GetUserProfileDetailsResDto } from './dto/get-user-profile-details-res.dto';
+import { GetUserByNicknameReqDto } from './dto/get-user-by-nickname-req.dto';
+import { FindUserByNicknameDto } from '../memoryuser/dto/find-user-by-nickname.dto';
+import { GetUserByNicknameResDto } from './dto/get-user-by-nickname-res.dto';
 
 @Controller('me')
 export class MeController {
@@ -30,7 +33,7 @@ export class MeController {
       .build();
   }
 
-  @Get('me/details')
+  @Get('details')
   getUserProfileDetails(@Session() session) {
     const me = this.memoryUserService.findUser(
       Builder(FindUserDto).userId(session.userId).build(),
@@ -43,6 +46,31 @@ export class MeController {
       .mail(me.mail)
       .phone(me.phone)
       .twoFactor(me.twoFactor)
+      .build();
+  }
+
+  @Get('users/:nickname')
+  getUserByNickname(@Session() session, @Param() dto: GetUserByNicknameReqDto) {
+    const me = this.memoryUserService.findUser(
+      Builder(FindUserDto).userId(session.userId).build(),
+    );
+    const findUser = this.memoryUserService.findUserByNickname(
+      Builder(FindUserByNicknameDto).nickname(dto.nickname).build(),
+    );
+
+    const gameRecodeDto = Builder(GameRecordDto)
+      .win(10)
+      .loss(10)
+      .ladderLevel(10)
+      .achievement(['0123456789abcdef', '0123456789abcdef'])
+      .build();
+    return Builder(GetUserByNicknameResDto)
+      .id(findUser.id)
+      .nickname(findUser.nickname)
+      .avatar(findUser.avatar)
+      .gameRecord(gameRecodeDto)
+      .isFriend(me.friends.has(findUser.id))
+      .isisBlock(me.blocks.has(findUser.id))
       .build();
   }
 }


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [x] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [x] 이슈 책임자(Assignees)를 추가했나요?
- [x] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [x] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [x] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?

# Summary(키워드 위주로 서술해주세요!)
- getUsetProfileDetailDto 추가

# Describe your changes
### 소스 추가
- dto가 추가되었습니다.
  (+) getUsetProfileDetailDto : 내 상세 프로필 조회에서 포함되지 않아 추가함.
- Mecontroller
  <img width="366" alt="스크린샷 2023-08-15 오후 10 56 12" src="https://github.com/5GoInMul-Transcendence/ft_transcendence/assets/90084199/436975cf-364f-4c60-8433-b84dbab855f9">

  현재 back-dev 브랜치에서 내 상세 프로필 조회의 경로가 'details'로 되어있으나
  다시 수정된 코드가 올라감. 수정된 코드가 맞으나 다시 올라간 이유는 모르겠음

# Issue number and link
- #84
