### PR TITLE
refactor: modify-the-message-when-the-username-or-password-is-incorrect

### DIFF
--- a/back/web-app/src/login/login.controller.ts
+++ b/back/web-app/src/login/login.controller.ts
@@ -33,10 +33,10 @@ export class LoginController {
 
     memberUser = await this.userService.getMemberUserByAccountId(id);
     if (!memberUser) {
-      throw new HttpException('ID가 존재하지 않습니다!', HttpStatus.OK);
+      throw new HttpException('아이디 또는 비밀번호가 올바르지 않습니다!', HttpStatus.OK);
     }
     if (memberUser.password !== password) {
-      throw new HttpException('Password가 일치하지 않습니다!', HttpStatus.OK);
+      throw new HttpException('아이디 또는 비밀번호가 올바르지 않습니다!', HttpStatus.OK);
     }
     if (this.loginService.isTwoFaOn(memberUser.user.twoFactor) == true) {
       // 2FA

--- a/back/web-app/src/signup/signup.controller.ts
+++ b/back/web-app/src/signup/signup.controller.ts
@@ -35,6 +35,8 @@ export class SignupController {
     user = await this.userService.createUser(
       Builder(CreateUserDto)
       .mail(null)
+      .build()
+    );
     this.memoryUserService.addUser(
       Builder(UserDto)
       .avatar(user.avatar)


### PR DESCRIPTION
…ct#106

- 로그인 시 아이디 또는 비밀번호가 틀렸을 때 메시지를 동일하게 변경함으로써 보안을 높였다.
- 이전 머지에서 자동으로 충돌해결 한 부분이 잘못 되어 수정했다.

<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [x] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [x] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [x] 이슈 책임자(Assignees)를 추가했나요?
- [x] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [x] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [x] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?

# Describe your changes
### build() 를 추가하여 성공적으로 회원가입함.
<img width="428" alt="image" src="https://github.com/5GoInMul-Transcendence/ft_transcendence/assets/83959536/6639c500-05f6-41f8-9ff3-dcecd6c3814d">

<img width="491" alt="image" src="https://github.com/5GoInMul-Transcendence/ft_transcendence/assets/83959536/0291f33c-6c1e-4a6a-9069-bca5de37b154">

### 아이디 또는 비밀번호가 올바르지 않을 때의 메시지
<img width="486" alt="image" src="https://github.com/5GoInMul-Transcendence/ft_transcendence/assets/83959536/ec544e5c-440e-4d88-91e9-eafb56af26eb">


# Issue number and link
- #106 
