### PR TITLE
bug: 아이디 및 비밀번호 틀렸을 시 잘못된 HTTP status code로 오는 것 수정#158

### DIFF
--- a/back/web-app/src/common/response/api-response-form.ts
+++ b/back/web-app/src/common/response/api-response-form.ts
@@ -9,22 +9,22 @@ export class ApiResponseForm {
     }
   }
 
-  static redirect(data: any = {}) {
-    return {
-      data,
-      resStatus: {
-        code : '0002',
-        message: '',
-      },
-    }
-  }
-
   static bad(message: string = '', data: any = {}) {
     return {
       data,
       resStatus: {
         code : '0001',
         message,
+      },
+    }
+  }
+  
+  static redirect(data: any = {}) {
+    return {
+      data,
+      resStatus: {
+        code : '0002',
+        message: '',
       },
     }
   }

--- a/back/web-app/src/common/response/fail/http-exception.filter.ts
+++ b/back/web-app/src/common/response/fail/http-exception.filter.ts
@@ -4,6 +4,11 @@ import { ApiResponseForm } from '../api-response-form';
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
+  /**
+    This is default codes in json method
+    timestamp: new Date().toISOString(),
+    path: request.url,
+  */
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
@@ -12,7 +17,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const message: string = exception.message;
 
     console.log('Exception filter\nSend Response\n');
-    if (status == HttpStatus.FOUND) {
+    if (status === HttpStatus.FOUND) {
       return (
         response
           .status(200)
@@ -20,13 +25,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
       );
     }
 
-    response
+    return response
+      .status(200)
       .json(ApiResponseForm.bad(message));
-
-      /**
-        // This is default codes in json method
-        timestamp: new Date().toISOString(),
-        path: request.url,
-       */
   }
 }

--- a/back/web-app/src/common/response/success-or-redirection/response.interceptor.ts
+++ b/back/web-app/src/common/response/success-or-redirection/response.interceptor.ts
@@ -19,11 +19,10 @@ export class ResponseInterceptor implements NestInterceptor {
           // test
           console.log('Post interceptor\nSend Response\n');
 
-          if (status == HttpStatus.FOUND) {
+          if (status === HttpStatus.FOUND) {
             response.status(HttpStatus.OK);
             return ApiResponseForm.redirect(data);
           }
-
           return ApiResponseForm.ok(data);
         }),
       );


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [x] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [x] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [x] 이슈 책임자(Assignees)를 추가했나요?
- [x] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [x] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [x] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?

# Describe your changes
## httpExceptionFilter, LoginController(컨트롤러는 참고)
- 우리가 의도한 대로라면 HttpException(~, HttpStatus.OK) 로 예외를
  던졌으므로 exception filter 에서 이를 catch 한다면 OK(200)으로
응답이 생성 되어야 한다 생각했는데 이는 302 로 가게 되었다.
- 찾아보니 200으로 던지면 exception filter 상에서는 200 으로 구분할 수
  있지만 최종적으로 responsse 로 만들어질 때 컨트롤러의 핸들러에 있는
@httpcode(HttpStatus.FOUND) 에 의해 200 -> 302 로 다시 변경 되어
보내진다고 한다. 때문에 우리가 실패했을 때 의도적으로 OK 를 던져
리다이렉션 할 때의 FOUND 와 분기하여 진행할 수는 있지만 실제 응답이
만들어질 때는 컨트롤로의 핸들러에서 설정한 code 로 만들어진다는 것이다.
때문에 보내기 전엔 response 의 status() 메소드로 의도한 상태 코드를 넣어 마무리해야
한다. 여기에선 HttpStatus.OK 를 넣어줬다.

## ApiResponseForm
- bad 와 redirect 의 resStatus.code 에 따라 정렬

## ResponseInterceptor, HttpExceptionFilter
- 내부에서 strict 비교를 하지 않고 일반 비교를 진행하는 것을 발견하여
  strict 로 변경

# Issue number and link
- #158 
