### PR TITLE
feat: 표시할 메시지 시간 순 정렬 변경#277

### DIFF
--- a/back/web-app/src/users/user/user.controller.ts
+++ b/back/web-app/src/users/user/user.controller.ts
@@ -25,7 +25,7 @@ export class UserController {
 
     const gameRecodeDto = Builder(GameRecordDto)
       .win(10)
-      .loss(10)
+      .lose(10)
       .ladderLevel(10)
       .achievement(['0123456789abcdef', '0123456789abcdef'])
       .build();


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->
# Describe your changes
- 기존 내림차 순으로 정렬된 배열을 오름차 순으로 변경하였다. 데이터베이스에 저장하는 것을 제어하지 못하고, 가져올 때 가장 위부터 순회 가능하니 이후 가공하는 방법 밖에 없다.
- 쿼리로 처리하려면 두 개 이상의 쿼리가 필요한 것 같아 메모리에서 처리하도록 단순하게 reverse 로 배열 저장 정렬 순서를 바꿨다.
   - 만약 쿼리로 한다면, 가장 최신 메시지의 timestamp 를 가져오는데 하나의 쿼리 사용
   - 이후 최신 메시지 기준 내림차 정렬 후 50개만 가져오는데, 이 때 이전에 가져온 최신 메시지의 시간과 비교하여 정렬. 최신 메시지가 없다면 그냥 빈 배열 반환.

# Issue number and link
- #227 
