### PR TITLE
[Refactor] Game 패들 충돌 수정

### DIFF
--- a/back/game-app/src/game/mode/game.abstract.ts
+++ b/back/game-app/src/game/mode/game.abstract.ts
@@ -1,15 +1,9 @@
-import {
-  BallOption,
-  PaddleOption,
-  ScoreOption,
-  SCREEN_HEIGHT,
-  SCREEN_WIDTH,
-} from './object/game-object.option';
-import { GameObjects, GameScore } from './object/game-object';
-import { PlayerAction } from '../player/enums/player-action.enum';
-import { PlayerNumber } from '../player/enums/player-number.enum';
-import { GamePlayResult } from './enums/game-play-result.enum';
-import { GameStatus } from './enums/game-status.enum';
+import {BallOption, PaddleOption, ScoreOption, SCREEN_HEIGHT, SCREEN_WIDTH,} from './object/game-object.option';
+import {GameObjects, GameScore} from './object/game-object';
+import {PlayerAction} from '../player/enums/player-action.enum';
+import {PlayerNumber} from '../player/enums/player-number.enum';
+import {GamePlayResult} from './enums/game-play-result.enum';
+import {GameStatus} from './enums/game-status.enum';
 
 export abstract class AbstractGame {
   public id: string;
@@ -75,6 +69,7 @@ export abstract class AbstractGame {
 
     /* p1 패들 충돌 체크 */
     if (
+      this.ballOption.nextHitPlayer == PlayerNumber.P1 &&
       this.objects.b.x <=
       this.objects.p1.x + this.paddleOption.width + this.ballOption.radius
     ) {
@@ -82,16 +77,20 @@ export abstract class AbstractGame {
         this.objects.b.y > this.objects.p1.y - this.ballOption.radius &&
         this.objects.b.y < this.objects.p1.y + this.paddleOption.height + this.ballOption.radius
       ) {
+        this.ballOption.nextHitPlayer = this.ballOption.nextHitPlayer % 2 + 1;
         this.ballOption.xDirection *= -1;
         this.ballOption.speed += this.ballOption.speedUp;
       }
     }
     /* p2 패들 충돌 체크 */
-    if (this.objects.b.x >= this.objects.p2.x) {
+    if (
+        this.ballOption.nextHitPlayer == PlayerNumber.P2 &&
+        this.objects.b.x >= this.objects.p2.x - this.ballOption.radius) {
       if (
-        this.objects.b.y > this.objects.p2.y &&
-        this.objects.b.y < this.objects.p2.y + this.paddleOption.height
+        this.objects.b.y > this.objects.p2.y - this.ballOption.radius &&
+        this.objects.b.y < this.objects.p2.y + this.paddleOption.height + this.ballOption.radius
       ) {
+        this.ballOption.nextHitPlayer = this.ballOption.nextHitPlayer % 2 + 1;
         this.ballOption.xDirection *= -1;
         this.ballOption.speed += this.ballOption.speedUp;
       }
@@ -143,5 +142,7 @@ export abstract class AbstractGame {
 
     this.ballOption.xDirection = Math.round(Math.random()) ? 1 : -1;
     this.ballOption.yDirection = Math.round(Math.random()) ? 1 : -1;
+    
+    this.ballOption.nextHitPlayer = this.ballOption.xDirection == -1 ? PlayerNumber.P1 : PlayerNumber.P2;
   }
 }

--- a/back/game-app/src/game/mode/object/game-object.option.ts
+++ b/back/game-app/src/game/mode/object/game-object.option.ts
@@ -1,3 +1,5 @@
+import {PlayerNumber} from '../../player/enums/player-number.enum';
+
 export const SCREEN_WIDTH = 1200;
 export const SCREEN_HEIGHT = 700;
 
@@ -15,7 +17,8 @@ export class BallOption {
   speedUp: number;
   xDirection: number;
   yDirection: number;
-
+  nextHitPlayer: PlayerNumber;
+  
   constructor() {
     this.radius = 12.5;
     this.speed = 8;

--- a/back/game-app/src/game/mode/object/game-object.option.ts
+++ b/back/game-app/src/game/mode/object/game-object.option.ts
@@ -21,7 +21,7 @@ export class BallOption {
   
   constructor() {
     this.radius = 12.5;
-    this.speed = 8;
+    this.speed = 6;
     this.speedUp = 0.05;
     this.xDirection = 1;
     this.yDirection = 1;

--- a/back/game-app/src/game/mode/speed-game.ts
+++ b/back/game-app/src/game/mode/speed-game.ts
@@ -4,6 +4,6 @@ export class SpeedGame extends AbstractGame {
   constructor(gameId: string) {
     super(gameId);
 
-    this.ballOption.speed = 12;
+    this.ballOption.speed = 10;
   }
 }


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?

# Describe your changes
## 구현 항목
### '공이 패들을 타고간다!' 버그
- 플레이어가 패들 이동시 공을 품을 경우 (패들 안에 공이 들어간 경우) 공이 패들을 따라 타고가는 버그가 있었습니다.
- 타고갔던 이유는, 패들 안에 있던 공이 반대편으로 이동 했음에도 패들 안에 있어 충돌 판정이 났고 다시 반대편으로 이동하게 되면서 반복되다보니 타고가는 것 처럼 보이게 되었습니다. 이를 수정하였습니다.

### 공 스피드 너프
- classic 게임의 공 속도를 8 -> 6으로 너프하였습니다.
- speed 게임의 공 속도를 12 -> 10으로 너프하였습니다. 
 

# Issue number and link
- 
