### PR TITLE
fix: 채널 확인 시 isBan 추가

### DIFF
--- a/back/web-app/src/channels/channel/channel.controller.ts
+++ b/back/web-app/src/channels/channel/channel.controller.ts
@@ -232,14 +232,21 @@ export class ChannelController {
 	}
 
 	@Get(':channelid/check')
-	async checkChannel(@Param('channelid') channelId: number): Promise<CheckChannelResDto> {
+	async checkChannel(
+		@Param('channelid') channelId: number,
+		@Session() session: Record<string, any>,
+	): Promise<CheckChannelResDto> {
 		const channel = await this.channelService.getChannel(channelId);
+		const userId: number = session.userId;
+		let isBan: boolean;
 
 		if (channel === null) {
 			this.exceptionService.notExistChannel();
 		}
+		isBan = this.userSettingService.isBanUser(channel.id, userId);
 		return Builder(CheckChannelResDto)
 		.mode(channel.mode)
+		.isBan(isBan)
 		.build();
 	}
 

--- a/back/web-app/src/channels/channel/dto/check-channel-res.dto.ts
+++ b/back/web-app/src/channels/channel/dto/check-channel-res.dto.ts
@@ -1,3 +1,4 @@
 export class CheckChannelResDto {
 	readonly mode: string;
+	readonly isBan: boolean;
 }


### PR DESCRIPTION
- 프론트에서 ban 되었는지 채널을 입장해야만 알기 때문에 ban 되어 채널에 나갔지만 채널을 보고 있는 유저에 대한 예외처리가 어려웠다. 이에 대해 애초에 채널에 들어가기 전에 항상 check 를 물어봐서 ban이면 프론트에서
enter channel 요청을 보내지 않는다.

<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야! -->

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?

# Describe your changes
- 커밋 메시지 확인 바랍니다.

